### PR TITLE
Added Correct Types for Kusama OpenGov Fast Track Support

### DIFF
--- a/src/tools/fast-execute-chopstick-proposal.ts
+++ b/src/tools/fast-execute-chopstick-proposal.ts
@@ -157,10 +157,20 @@ const main = async () => {
       alarm: [proposalBlockTarget + 1, [proposalBlockTarget + 1, 0]],
     },
   };
-  const fastProposal = api.registry.createType(
-    `Option<PalletReferendaReferendumInfo>`,
-    fastProposalData
-  );
+
+  let fastProposal;
+  try {
+    fastProposal = api.registry.createType(
+      `Option<PalletReferendaReferendumInfo>`,
+      fastProposalData
+    );
+  } catch {
+    fastProposal = api.registry.createType(
+      `Option<PalletReferendaReferendumInfoConvictionVotingTally>`,
+      fastProposalData
+    );
+  }
+
   console.log(
     `${chalk.blue("SetStorage")} Fast Proposal: ${chalk.red(
       proposalIndex.toString()


### PR DESCRIPTION
Kusama has a different type set for `ReferendumInfo`  - As it differs from Moonriver I've added support for both